### PR TITLE
update expression for slight delay

### DIFF
--- a/TrinketFakeUsbSerialHostSW/TrinketFakeUsbSerialHostSW_Python/TrinketFakeUsbSerialHostSW.py
+++ b/TrinketFakeUsbSerialHostSW/TrinketFakeUsbSerialHostSW_Python/TrinketFakeUsbSerialHostSW.py
@@ -114,13 +114,14 @@ def main(argv):
 
             except Exception as ex:
                 exStr = str(ex).lower()
-                if 'timeout' not in exStr: # ignore timeout errors, but all other errors signifies that the device disconnected
+                if "timed out" in exStr or "timeout" in exStr: # ignore timeout errors
+                    time.sleep(0.01) # slight delay
+                else: # all other errors signifies that the device disconnected
                     if silent == False:
                         print 'USB read error: ', ex
                     time.sleep(0.1) # don't hog all CPU
                     trinketHandle = False # disconnect to reacquire
                     break
-                time.sleep(0.01) # slight delay
 
         # end of while
         thisMsg = 'Trinket Disconnected'


### PR DESCRIPTION
USB Timeout Message changed to "[Errno 60] Operation timed out", so message not matched "timeout".
environment: pyusb-1.0.0b2-py2.7
